### PR TITLE
The module name should be 'request' and not 'requests'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "oauth": ">= 0.9.2",
-    "requests": "^0.2.2",
+    "request": "^0.2.2",
     "xml2js": ">= 0.1.9"
   },
   "directories": {


### PR DESCRIPTION
That explains why I had to install the `request` module for my app.